### PR TITLE
Update Vapor version to make it run 🚀

### DIFF
--- a/App/Room.swift
+++ b/App/Room.swift
@@ -10,7 +10,7 @@ class Room {
     func send(name: String, message: String) throws {
         let message = message.truncated(to: 256)
 
-        let json = try JSON([
+        let json = try JSON(node: [
             "username": name,
             "message": message
         ])

--- a/App/main.swift
+++ b/App/main.swift
@@ -7,7 +7,7 @@ let drop = Droplet(workDir: workDir) //, providers: [mustache])
 
 drop.get { req in
     // Design from: http://codepen.io/supah/pen/jqOBqp?utm_source=bypeople
-    return try drop.view("welcome.html")
+    return try drop.view.make("welcome.html")
 }
 
 // MARK: Sockets
@@ -20,7 +20,7 @@ drop.socket("chat") { req, ws in
     ws.onText = { ws, text in
         let json = try JSON(bytes: Array(text.utf8))
 
-        if let u = json.object?["username"].string {
+        if let u = json.object?["username"]?.string {
             username = u
             room.connections[u] = ws
             try room.bot("\(u) has joined. 👋")
@@ -41,5 +41,5 @@ drop.socket("chat") { req, ws in
     }
 }
 
-drop.serve()
+drop.run()
 

--- a/Package.swift
+++ b/Package.swift
@@ -3,7 +3,7 @@ import PackageDescription
 let package = Package(
     name: "VaporApp",
     dependencies: [
-        .Package(url: "https://github.com/qutheory/vapor.git", majorVersion: 0, minor: 15),
+        .Package(url: "https://github.com/vapor/vapor.git", majorVersion: 1, minor: 1)
         ],
     exclude: [
         "Config",


### PR DESCRIPTION
Just cloning and running this example didn’t work so I updated the repo. 

I'm still getting these warning when running:
``` bash
➜  chat-example git:(master) vapor run
Running VaporApp...
No command supplied, defaulting to serve...
No preparations.
Server 'default' starting at 0.0.0.0:8080
GET /
GET /scripts/chat.js
GET /styles/style.css
GET /styles/normalize.css
Response had no 'Content-Type' header.
Response had no 'Content-Type' header.
Response had no 'Content-Type' header.
GET /styles/normalize.css
Response had no 'Content-Type' header.
GET /styles/style.css
Response had no 'Content-Type' header.
GET /scripts/chat.js
Response had no 'Content-Type' header.
GET /chat
Response had no 'Content-Type' header.
```

Any idea why?